### PR TITLE
[travis] Don't use incorrect git submodule call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ install:
 - opam switch
 - opam list
 - opam config var root
-- git submodule update --remote
 
 script:
 - echo 'Using Node.js:' && node --version


### PR DESCRIPTION
This is updating not to the pinned module but to the remote, which
will make CI fail.

Travis should take care of the submodules already via

```
git:
  submodules: true
```

which IIANM is the default.