### PR TITLE
Hacky fix for side-effects in proofs anomaly

### DIFF
--- a/coq-js/jscoq_doc.ml
+++ b/coq-js/jscoq_doc.ml
@@ -78,16 +78,16 @@ let parse ~doc ~ontop stm =
  * if I think we agree this shouldn't be possible. Then, we add and
  * update our document.
  *)
-let add ~doc ~ontop ~newid stm =
+let add ~doc ~ontop stm =
   let doc, sdoc = doc in
   let verb = false                                       in
   if not (List.mem ontop sdoc) then raise (NoSuchState ontop);
   let pa = Pcoq.Parsable.make (Stream.of_string stm)     in
   let entry = Pvernac.main_entry in
   let east = Option.get Stm.(parse_sentence ~doc ~entry ontop pa) in
-  let ndoc, new_st, foc = Stm.add ~doc ~ontop ~newtip:newid verb east in
+  let ndoc, new_st, foc = Stm.add ~doc ~ontop verb east in
   let new_sdoc = new_st :: sdoc in
-  east.CAst.loc, foc, (ndoc,new_sdoc)
+  east.CAst.loc, new_st, foc, (ndoc,new_sdoc)
 
 let query ~doc ~at ~route query =
   let doc, sdoc = doc in

--- a/coq-js/jscoq_doc.mli
+++ b/coq-js/jscoq_doc.mli
@@ -22,9 +22,8 @@ val parse :
 val add :
   doc:ser_doc        ->
   ontop:Stateid.t    ->
-  newid:Stateid.t    ->
   string             ->
-  Loc.t option * [ `NewTip | `Unfocus of Stateid.t ] * ser_doc
+  Loc.t option * Stateid.t * [ `NewTip | `Unfocus of Stateid.t ] * ser_doc
 
 val query :
   doc:ser_doc              ->


### PR DESCRIPTION
This fixes #129 and probably also fixes #106.

This is a complete hack, and among other things introduces a memory leak. However, it does mostly seem to work. There still appear to be some issues with `Require` that are intermittent.

Because this is a total hack, I don't really expect this to be merged. But maybe it could be stored in a branch in case other people need it.