### PR TITLE
[build] Bump required compiler version to 4.10.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
  - Update to Coq 8.13.0 , mostly straightforward but build
    requirements have changed, in particular we now require
    `js_of_ocaml >= 3.8.0` (@ejgallego)
+ - Bump required compiler version to 4.10.2 (@ejgallego)
 
 # jsCoq 0.12.2 "Square Peg, Round Hole"
 ---------------------------------------

--- a/docs/build.md
+++ b/docs/build.md
@@ -20,12 +20,12 @@ git clone --recursive git@github.com:ejgallego/jscoq.git  # (this repo)
 cd jscoq
 ```
 
- 2. Install OCaml 4.08.1 (32-bit version) and required packages.
+ 2. Install OCaml 4.10.2 (32-bit version) and required packages.
 ```sh
 ./etc/toolchain-setup.sh     # optionally --64, see below
 ```
  **Note 1**: This will create an OPAM switch called `jscoq+32bit` using the
- `4.07.1+32bit` compiler, which the build will then use. You can modify/tweak
+ `4.10.2+32bit` compiler, which the build will then use. You can modify/tweak
  this switch without affecting your main OCaml installation.
 
  **Note 2:** On macOS 10.14 and above and on WSL you will have trouble building

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN opam init -a --bare --disable-sandboxing
 # -----------------
 # jsCoq pre-install
 # -----------------
-RUN opam switch create jscoq+64bit ocaml-base-compiler.4.08.1
+RUN opam switch create jscoq+64bit ocaml-base-compiler.4.10.2
 
 ENV APT_PACKAGES="git rsync bzip2 nodejs curl libgmp-dev"
 RUN apt install --no-install-recommends -y $APT_PACKAGES

--- a/etc/toolchain-setup.sh
+++ b/etc/toolchain-setup.sh
@@ -6,7 +6,7 @@ VERB= # -vv
 # Default OCaml version
 case `uname`-`uname -m` in
   Darwin-arm64) OCAML_VER=4.10.2 ;;  # older versions don't work on arm64
-  *)            OCAML_VER=4.08.1 ;;
+  *)            OCAML_VER=4.10.2 ;;
 esac
 
 # Default word size

--- a/jscoq.opam
+++ b/jscoq.opam
@@ -11,24 +11,24 @@ license:      "AGPL-3.0-or-later"
 doc:          "https://github.com/jscoq/jscoq#readme"
 
 depends: [
-  "ocaml"               { >= "4.07.1"           }
-  "dune"                { >= "2.4.0"            }
+  "ocaml"               { >= "4.10.2"           }
+  "dune"                { >= "2.8.0"            }
   "js_of_ocaml"         { >= "3.8.0"            }
   "js_of_ocaml-ppx"     { >= "3.8.0"            }
   "js_of_ocaml-lwt"     { >= "3.8.0"            }
   "yojson"              { >= "1.7.0"            }
-  "ppx_deriving_yojson" { >= "3.5.1"            }
-  "ppx_import"          { build & >= "1.6.2"    }
-  "lwt_ppx"             { >= "1.2.4"            }
+  "ppx_deriving_yojson" { >= "3.6.1"            }
+  "ppx_import"          { >= "1.8.0"            }
+  "lwt_ppx"             { >= "2.0.1"            }
   # We should just rely on OPAM's serlib but this is still early
-  "sexplib"             { >= "v0.12.0"           }
-  "ppx_sexp_conv"       { build   & >= "v0.12.0" }
+  "sexplib"             { >= "v0.14.0"          }
+  "ppx_sexp_conv"       { >= "v0.14.1"          }
   # We build a local, patched Coq, but however it is still a dependency and
   # we could build from the opam-installed setup.
   # "coq"                 { >= "8.13.0" & < "8.14" }
   # This are dependencies of Coq itself.
-  "zarith"              { >= "1.10" }
-  "zarith_stubs_js"
+  "zarith"              { >= "1.11"    }
+  "zarith_stubs_js"     { >= "v0.14.0" }
 ]
 
 build: [ "dune" "build" "-p" name "-j" jobs ]


### PR DESCRIPTION
We also bump some other libraries as to reduce non-deterministic
developer switches.

This is the part of #223 that can be merged now, pending M1 support on 4.11.2