### PR TITLE
[ci] Add step to build Docker image.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,22 @@ jobs:
           echo 'Building Addons...' && echo -en 'travis_fold:start:addons.build\\r'
           make addons
           # echo -en 'travis_fold:end:addons.build\\r'
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          file: etc/docker/Dockerfile
+          push: false
+          tags: jscoq/jscoq:latest
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       # - name: Login to DockerHub
@@ -85,11 +87,12 @@ jobs:
       #   with:
       #     username: ${{ secrets.DOCKERHUB_USERNAME }}
       #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
+      - name: Build (no push atm)
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           file: etc/docker/Dockerfile
+          context: etc/docker
           push: false
           tags: jscoq/jscoq:latest
       - name: Image digest

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -80,23 +80,27 @@ WORKDIR jscoq-addons
 RUN make set-ver VER=`jscoq --version`
 RUN eval $(opam env) && make
 
-# EJGA we need to figure this out.
 # Private repos: re-enable SSH
-# COPY /_ssh /_ssh 
-# RUN [ -e /_ssh/id_rsa ] && rm ~/.gitconfig && apt-get install -y openssh-client
-# ENV GIT_SSH_COMMAND 'ssh -i /_ssh/id_rsa -o StrictHostKeyChecking=no'
+COPY Dockerfile _ssh* /root/_ssh/
+#    ^ this is a hack in case `_ssh` does not exist (https://stackoverflow.com/a/46801962/37639)
+ENV GIT_SSH_COMMAND 'ssh -i /root/_ssh/id_rsa -o StrictHostKeyChecking=no'
 
-# RUN [ -e /_ssh/id_rsa ] && eval $(opam env) && make privates WITH_PRIVATE=software-foundations
+RUN if [ -e /root/_ssh/id_rsa ] ; then rm ~/.gitconfig && apt-get install -y openssh-client ; fi
+RUN if [ -e /root/_ssh/id_rsa ] ; then eval $(opam env) && make privates WITH_PRIVATE=software-foundations ; fi
 
 RUN make pack
 
+# ---------
 # jsCoq SDK
+# ---------
 
-#RUN cp -rL _build/install/jscoq+64bit/ ./dist && \
-#    rm dist/bin/*.byte dist/bin/*.opt \
-#       dist/lib/coq/*/*.cmxs \
-#       `find dist -regex '.*\.\(cm\(a\|t\|ti\)\|mli?\)'`
+FROM jscoq as jscoq-sdk-prepare
 
-#FROM debian:10-slim
+RUN cp -rL _build/install/jscoq+*bit/ ./dist && \
+    rm dist/bin/*.byte dist/bin/*.opt \
+       dist/lib/coq/*/*.cmxs \
+       `find dist -regex '.*\.\(cm\(a\|t\|ti\)\|mli?\)'`
 
-#COPY --from=0 /root/jscoq/dist /opt/jscoq
+FROM debian:10-slim as jscoq-sdk
+
+COPY --from=jscoq-sdk-prepare /root/jscoq/dist /opt/jscoq

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -80,12 +80,13 @@ WORKDIR jscoq-addons
 RUN make set-ver VER=`jscoq --version`
 RUN eval $(opam env) && make
 
+# EJGA we need to figure this out.
 # Private repos: re-enable SSH
-COPY /_ssh /_ssh 
-RUN [ -e /_ssh/id_rsa ] && rm ~/.gitconfig && apt-get install -y openssh-client
-ENV GIT_SSH_COMMAND 'ssh -i /_ssh/id_rsa -o StrictHostKeyChecking=no'
+# COPY /_ssh /_ssh 
+# RUN [ -e /_ssh/id_rsa ] && rm ~/.gitconfig && apt-get install -y openssh-client
+# ENV GIT_SSH_COMMAND 'ssh -i /_ssh/id_rsa -o StrictHostKeyChecking=no'
 
-RUN [ -e /_ssh/id_rsa ] && eval $(opam env) && make privates WITH_PRIVATE=software-foundations
+# RUN [ -e /_ssh/id_rsa ] && eval $(opam env) && make privates WITH_PRIVATE=software-foundations
 
 RUN make pack
 

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -96,11 +96,11 @@ RUN make pack
 
 FROM jscoq as jscoq-sdk-prepare
 
-RUN cp -rL _build/install/jscoq+*bit/ ./dist && \
-    rm dist/bin/*.byte dist/bin/*.opt \
-       dist/lib/coq/*/*.cmxs \
+RUN cp -rL _build/install/jscoq+*bit/ ./dist-sdk && \
+    rm dist-sdk/bin/*.byte dist-sdk/bin/*.opt \
+       dist-sdk/lib/coq/*/*.cmxs \
        `find dist -regex '.*\.\(cm\(a\|t\|ti\)\|mli?\)'`
 
 FROM debian:10-slim as jscoq-sdk
 
-COPY --from=jscoq-sdk-prepare /root/jscoq/dist /opt/jscoq
+COPY --from=jscoq-sdk-prepare /root/jscoq/dist-sdk /opt/jscoq


### PR DESCRIPTION
This still requires considerable work, but when ready it should
solve parts of #69 and #121.

As for now, we don't push the image to a registry yet; we ought to
decide:

- when to build the docker image [maybe only on main branches]
- where to push it
- what to include
- a standard setup for addons CI, so they pull the image and then
  build and publish their own package
- how this does integrate with npm, maybe we shouldn't push the image
  but just a npm package built using docker [so addons do get the
  correct binaries to push to npm too]

Based on:

https://github.com/marketplace/actions/build-and-push-docker-images