### PR TITLE
Dual-branch Dockerfile

### DIFF
--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -19,26 +19,35 @@ ENV OPAMJOBS=${NJOBS}          \
 
 RUN opam init -a --bare --disable-sandboxing
 
+# ----------------------------------------------------------
+#
+#       j s C o q   (JavaScript backend)
+#
+# ----------------------------------------------------------
+
 # -----------------
 # jsCoq pre-install
 # -----------------
+FROM opam as jscoq-preinstall
+
 RUN opam switch create jscoq+32bit --packages="ocaml-variants.4.12.0+options,ocaml-option-32bit"
 
+# Other deps: Git, Node.js, GMP
 ENV APT_PACKAGES="git rsync bzip2 nodejs curl libgmp-dev"
+RUN wget -O- https://deb.nodesource.com/setup_16.x | bash -
+# ^ https://github.com/nodesource/distributions/blob/master/README.md
 RUN apt install --no-install-recommends -y $APT_PACKAGES
-RUN curl https://www.npmjs.com/install.sh | sh
-# ^ https://github.com/nodejs/help/issues/1877
 
 # ---------------------
 # jsCoq toolchain setup
 # ---------------------
-FROM opam as jscoq-prereq
+FROM jscoq-preinstall as jscoq-prereq
 
-ARG REPO=https://github.com/jscoq/jscoq
-ARG BRANCH=v8.13
+ARG JSCOQ_REPO=https://github.com/jscoq/jscoq
+ARG JSCOQ_BRANCH=v8.13
 
 WORKDIR /root
-RUN git clone --recursive -b ${BRANCH} ${REPO}
+RUN git clone --recursive -b ${JSCOQ_BRANCH} ${JSCOQ_REPO}
 
 WORKDIR jscoq
 RUN ./etc/toolchain-setup.sh --32
@@ -106,3 +115,107 @@ RUN cp -rL _build/install/jscoq+*bit/ ./dist-sdk && \
 FROM debian:10-slim as jscoq-sdk
 
 COPY --from=jscoq-sdk-prepare /root/jscoq/dist-sdk /opt/jscoq
+
+# ----------------------------------------------------------
+#
+#       w a C o q   (WebAssembly backend)
+#
+# ----------------------------------------------------------
+
+# -----------------
+# waCoq pre-install
+# -----------------
+FROM opam as wacoq-preinstall
+
+RUN opam switch create wacoq --packages="ocaml-base-compiler.4.12.0"
+
+ENV APT_PACKAGES="git rsync bzip2 nodejs curl libgmp-dev"
+RUN wget -O- https://deb.nodesource.com/setup_16.x | bash -
+# ^ https://github.com/nodesource/distributions/blob/master/README.md
+RUN apt-get install --no-install-recommends -y $APT_PACKAGES
+#RUN curl https://www.npmjs.com/install.sh | sh
+## ^ https://github.com/nodejs/help/issues/1877
+
+ARG WASI_SDK_URL="https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz"
+RUN wget -O/tmp/wasi-sdk.tar.gz ${WASI_SDK_URL}
+RUN ( cd /opt && tar xf /tmp/wasi-sdk.tar.gz && ln -s wasi-sdk-* wasi-sdk )
+
+# ---------------------
+# waCoq toolchain setup
+# ---------------------
+FROM wacoq-preinstall as wacoq-prereq
+
+ARG WACOQ_BIN_REPO=https://github.com/corwin-of-amber/wacoq-bin.git
+ARG WACOQ_BIN_BRANCH=v8.13
+
+WORKDIR /root
+RUN git clone --recursive -b ${WACOQ_BIN_BRANCH} ${WACOQ_BIN_REPO} wacoq-bin
+
+WORKDIR wacoq-bin
+RUN opam update
+RUN ./etc/setup.sh
+RUN opam clean -a -c
+RUN opam list
+
+# -----------------
+# waCoq+jsCoq build
+# -----------------
+FROM wacoq-prereq as wacoq
+
+ARG JSCOQ_REPO=https://github.com/jscoq/jscoq.git
+ARG JSCOQ_BRANCH=v8.13
+
+ARG NJOBS=4
+
+RUN git pull
+RUN npm install
+RUN eval $(opam env) && make coq && make
+RUN make dist-npm
+
+WORKDIR /root
+RUN git clone --recursive -b ${JSCOQ_BRANCH} ${JSCOQ_REPO} jscoq+wacoq
+
+WORKDIR jscoq+wacoq
+RUN npm install ../wacoq-bin/wacoq-bin-*.tar.gz
+RUN npm install
+RUN make wacoq
+RUN make dist-npm-wacoq
+
+# - dist tarballs
+# @oops `dist` is also used by the build...
+RUN rm -rf dist && mkdir dist && mv *.tgz ../wacoq-bin/*.tar.gz dist
+
+# --------------
+# Addon packages
+# --------------
+FROM wacoq as wacoq-addons
+
+ARG ADDONS_REPO=https://github.com/jscoq/addons
+ARG ADDONS_BRANCH=v8.13
+
+ARG CONTEXT=wacoq
+
+# - install to OPAM for use by package builds
+WORKDIR /root/wacoq-bin
+RUN eval $(opam env) && make install && npm link
+
+# - fetch submodules with ssh urls using https instead
+#   (to avoid the need for an ssh key)
+RUN git config --global url."https://github.com/".insteadOf git@github.com:
+
+WORKDIR /root
+RUN git clone --recursive -b ${ADDONS_BRANCH} ${ADDONS_REPO} jscoq-addons
+
+WORKDIR jscoq-addons
+RUN make set-ver CONTEXT=${CONTEXT}
+RUN eval $(opam env) && make CONTEXT=${CONTEXT}
+
+# Private repos: re-enable SSH
+COPY Dockerfile _ssh* /root/_ssh/
+#    ^ this is a hack in case `_ssh` does not exist (https://stackoverflow.com/a/46801962/37639)
+ENV GIT_SSH_COMMAND 'ssh -i /root/_ssh/id_rsa -o StrictHostKeyChecking=no'
+
+RUN if [ -e /root/_ssh/id_rsa ] ; then rm ~/.gitconfig && apt-get update && apt-get install -y openssh-client ; fi
+RUN if [ -e /root/_ssh/id_rsa ] ; then eval $(opam env) && make privates WITH_PRIVATE=software-foundations CONTEXT=${CONTEXT} ; fi
+
+RUN make pack CONTEXT=${CONTEXT}

--- a/etc/docker/Makefile
+++ b/etc/docker/Makefile
@@ -1,37 +1,66 @@
-.PHONY: build dist serve
+.PHONY: build dist serve clean clean-% wa-% js-%
 
 WHO = jscoq
 
-export REPO = https://github.com/$(WHO)/jscoq
-export BRANCH = v8.13
+export JSCOQ_REPO = https://github.com/$(WHO)/jscoq.git
+export JSCOQ_BRANCH = v8.13
+
+export WACOQ_BIN_REPO = https://github.com/corwin-of-amber/wacoq-bin.git
+export WACOQ_BIN_BRANCH = v8.13
+
 export NJOBS ?= 4
 
-ARGS = --build-arg REPO --build-arg BRANCH --build-arg NJOBS
-# --progress plain --no-cache=true
+# Use BuildKit.
+# This is needed for jscoq/wacoq branching in Dockerfile
+export DOCKER_BUILDKIT = 1
+
+ARGS = --build-arg JSCOQ_REPO --build-arg JSCOQ_BRANCH \
+	   --build-arg WACOQ_BIN_REPO --build-arg WACOQ_BIN_BRANCH \
+	   --build-arg NJOBS
 
 -include _config.mk
 
 EXISTING_IMAGES = ${shell docker images --filter=reference="jscoq:*" --format '{{.Repository}}:{{.Tag}}'}
+EXISTING_IMAGES += ${shell docker images --filter=reference="wacoq:*" --format '{{.Repository}}:{{.Tag}}'}
 
-build:
-	docker build . --target opam         $(ARGS)  -t jscoq:opam
-	docker build . --target jscoq-prereq $(ARGS)  -t jscoq:prereq
-	docker build . --target jscoq        $(ARGS)  -t jscoq
-	docker build . --target jscoq-addons $(ARGS)  -t jscoq:addons
+js-build:
+	docker build . --target jscoq-preinstall $(ARGS)  -t jscoq:preinstall
+	docker build . --target jscoq-prereq     $(ARGS)  -t jscoq:prereq
+	docker build . --target jscoq            $(ARGS)  -t jscoq
+	docker build . --target jscoq-addons     $(ARGS)  -t jscoq:addons
 
-dist:
+wa-build:
+	docker build . --target wacoq-preinstall $(ARGS)  -t wacoq:preinstall
+	docker build . --target wacoq-prereq     $(ARGS)  -t wacoq:prereq
+	docker build . --target wacoq            $(ARGS)  -t wacoq
+	docker build . --target wacoq-addons     $(ARGS)  -t wacoq:addons
+
+dist: js-dist wa-dist
+
+clean-dist:
 	rm -rf ./dist
+
+js-dist: clean-dist
 	docker run --name jscoq-get-dist jscoq:addons \
 		sh -c 'mkdir -p dist && cp _build/jscoq+*/*.tgz dist'
 	docker cp jscoq-get-dist:/root/jscoq/dist .
 	docker cp jscoq-get-dist:/root/jscoq-addons/dist .
 	docker rm jscoq-get-dist
 
+wa-dist: clean-dist
+	docker run --name wacoq-get-dist wacoq:addons \
+		sh -c 'mkdir -p dist && cp _build/wacoq/*.tgz dist'
+	docker cp wacoq-get-dist:/root/jscoq+wacoq/dist .
+	docker cp wacoq-get-dist:/root/jscoq-addons/dist .
+	docker rm wacoq-get-dist
+
+I = ${filter-out jscoq:pre% wacoq:pre%, $(EXISTING_IMAGES)}
+
 clean:
-	docker image rm ${filter-out jscoq:opam jscoq:prereq, $(EXISTING_IMAGES)}
+	${if $(I), docker image rm $(I)}
 
 clean-slate:
-	docker image rm $(EXISTING_IMAGES)
+	${if $(EXISTING_IMAGES), docker image rm $(EXISTING_IMAGES)}
 
 serve:
 	docker run --publish 8080:8080 --rm -it jscoq \
@@ -41,4 +70,4 @@ dist-serve:
 	npx http-server -p 8080 dist
 
 ci:
-	make clean && make && make dist
+	make clean && make js-build wa-build && make dist


### PR DESCRIPTION
This requires running with BuildKit if you want to build the WA branch of the build and skip JS.

Building JS should still work with older Docker.