### PR TITLE
[cleanup] Reify CoqExn data into a Json object

### DIFF
--- a/coq-js/jscoq_proto.ml
+++ b/coq-js/jscoq_proto.ml
@@ -154,7 +154,11 @@ type jscoq_answer =
   | Compiled  of string
 
   (* Low-level *)
-  | CoqExn    of Loc.t option * (Stateid.t * Stateid.t) option * Pp.t
+  | CoqExn    of { loc : Loc.t option
+                 ; sid : (Stateid.t * Stateid.t) option
+                 ; msg : string
+                 ; pp : Pp.t
+                 }
   | JsonExn   of string
   [@@deriving to_yojson]
 end

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -773,7 +773,11 @@ class CoqManager {
         this.layout.log(`Package '${bname}' is missing (${msg})`, 'Warning');
     }
 
-    coqCoqExn(loc, sids, msg) {
+    coqCoqExn(exn) {
+
+        let msg = exn.pp;
+        let sids = exn.sid;
+
         console.error('Coq Exception', msg);
 
         // If error has already been reported by Feedback, bail

--- a/ui-js/headless.ts
+++ b/ui-js/headless.ts
@@ -249,7 +249,11 @@ class HeadlessCoqManager {
             console.log('Canceled', sid);
     }
 
-    coqCoqExn(loc, _, msg) {
+    coqCoqExn(exn) {
+
+        let msg = exn.pp;
+        let loc = exn.loc;
+
         var loc_repr = this._format_loc(loc);
         console.error(`[Exception] ${this.pprint.pp2Text(msg)}${loc_repr}`);
         this.when_done.reject({loc, error: msg});

--- a/ui-js/ide-project.js
+++ b/ui-js/ide-project.js
@@ -529,8 +529,13 @@ class BuildReport {
     }
 
     decorateError(coqexn, mod) {
-        let [, loc, , msg] = coqexn,
-            err = {loc: {filename: mod.physical.replace(/^[/]/, '')}};
+
+        let [,exn] = coqexn;
+        let msg = exn.pp;
+        let loc = exn.loc;
+
+        let err = {loc: {filename: mod.physical.replace(/^[/]/, '')}};
+
         // Convert character positions to {line, ch}
         if (loc) {
             try {


### PR DESCRIPTION
That's better w.r.t. future, we also add a msg field which is the
rendered plain string, useful when debugging early stages or low-level
as the CoqPP is hard to read and in that setup, we may not be able to
to access the pp printer yet.

Backported from the 8.14 branch, as it is and independent change that should be reviewed separatedly.