### PR TITLE
[jscoq] Preliminary upgrade to Coq 8.16

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# jsCoq 0.16.0 "Plugin or not plugin"
+-------------------------------------
+
+ - Update to Coq 8.16.0 (@corwin-of-amber, @ejgallego)
+ - Now Coq loads plugins with using findlib
+
 # jsCoq 0.15.1 "Go For Your Toad, or Similar"
 ---------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 -include ./config.inc
 
 # Coq Version
-COQ_VERSION := v8.15
+COQ_VERSION := v8.16
 JSCOQ_BRANCH :=
 
 JSCOQ_VERSION := $(COQ_VERSION)
@@ -206,8 +206,8 @@ dist-npm-wacoq:
 
 .PHONY: coq coq-get coq-get-latest coq-build
 
-COQ_BRANCH = V8.15.1
-COQ_BRANCH_LATEST = v8.15
+COQ_BRANCH = V8.16+rc1
+COQ_BRANCH_LATEST = v8.16
 COQ_REPOS = https://github.com/coq/coq.git
 
 COQ_PATCHES = trampoline fold timeout $(COQ_PATCHES|$(WORD_SIZE)) $(COQ_PATCHES|$(ARCH))

--- a/coq-js/icoq.mli
+++ b/coq-js/icoq.mli
@@ -19,7 +19,7 @@ type async_flags = {
   deep_edits   : bool;
 }
 
-type require_lib = (string * string option * bool option)
+type require_lib = (string * string option * Lib.export_flag option)
 type top_mode = Interactive | Vo
 
 type coq_opts = {

--- a/coq-js/jscoq_interp.ml
+++ b/coq-js/jscoq_interp.ml
@@ -116,7 +116,11 @@ let requires ast =
     let prefix_str = match prefix with
     | Some ref -> Jslibmng.module_name_of_qualid ref
     | _ -> [] in
-    let module_refs_str = List.map (fun modref -> Jslibmng.module_name_of_qualid modref) module_refs in
+    let module_refs_str =
+      (* XXX *)
+      let module_refs = List.map fst module_refs in
+      List.map (fun modref -> Jslibmng.module_name_of_qualid modref) module_refs
+    in
     Some ((prefix_str, module_refs_str))
   | _ -> None
   [@@warning "-4"]
@@ -248,7 +252,8 @@ let jscoq_execute =
     out_fn @@ Ready iid
 
   | LoadPkg(base, pkg)  ->
-    Lwt.async (fun () -> Jslibmng.load_pkg process_lib_event base pkg)
+    let verb = false in
+    Lwt.async (fun () -> Jslibmng.load_pkg ~verb process_lib_event base pkg)
 
   | InfoPkg(base, pkgs) ->
     Lwt.async (fun () -> Jslibmng.info_pkg post_lib_event base pkgs)

--- a/coq-js/jslibmng.mli
+++ b/coq-js/jslibmng.mli
@@ -30,7 +30,7 @@ type out_fn = lib_event -> unit
 val info_pkg : out_fn -> string -> string list -> unit Lwt.t
 
 (** [load_pkg base_path pkg_file] loads package [pkg_file] *)
-val load_pkg : out_fn -> string -> string -> unit Lwt.t
+val load_pkg : verb:bool -> out_fn -> string -> string -> unit Lwt.t
 (** [info_pkg lib_path available_pkg ] gather package list
     [available_pkg] from directory [lib_path] *)
 
@@ -48,7 +48,7 @@ val path_to_coqpath : ?implicit:bool -> ?unix_prefix:string list -> string list 
 val paths_to_coqpath : ?implicit:bool -> (string list * string list) list -> Loadpath.vo_path list
 val coqpath_of_bundle : ?implicit:bool -> Jslib.coq_bundle -> Loadpath.vo_path list
 
-val require_libs : string list -> (string * string option * bool option) list
+val require_libs : string list -> (string * string option * Lib.export_flag option) list
 
 val path_of_dirpath : Names.DirPath.t -> string list
 val module_name_of_qualid : Libnames.qualid -> string list

--- a/etc/patches/coerce-32bit.patch
+++ b/etc/patches/coerce-32bit.patch
@@ -1,5 +1,5 @@
 diff --git a/clib/hashset.ml b/clib/hashset.ml
-index ae43e7d..883decb 100644
+index 183c997..b2af771 100644
 --- a/clib/hashset.ml
 +++ b/clib/hashset.ml
 @@ -11,6 +11,8 @@
@@ -11,7 +11,7 @@ index ae43e7d..883decb 100644
  (** The following functor is a specialized version of [Weak.Make].
      Here, the responsibility of computing the hash function is now
      given to the caller, which makes possible the interleaving of the
-@@ -229,9 +231,9 @@ module Combine = struct
+@@ -230,9 +232,9 @@ module Combine = struct
         this topic. Therefore, there must be room for improvement here. *)
      let alpha = 65599
      let beta  = 7
@@ -24,7 +24,7 @@ index ae43e7d..883decb 100644
 +    let combinesmall x y = (beta * x + y) land 0x3fffffff
  end
 diff --git a/kernel/dune b/kernel/dune
-index 88d059e..f2aeb95 100644
+index 228ea54..83d907f 100644
 --- a/kernel/dune
 +++ b/kernel/dune
 @@ -16,12 +16,12 @@
@@ -43,7 +43,7 @@ index 88d059e..f2aeb95 100644
  
  (documentation
 diff --git a/kernel/nativecode.ml b/kernel/nativecode.ml
-index 595aaae..3349370 100644
+index f9c07d3..9a259ee 100644
 --- a/kernel/nativecode.ml
 +++ b/kernel/nativecode.ml
 @@ -18,6 +18,8 @@ open Nativevalues
@@ -52,11 +52,11 @@ index 595aaae..3349370 100644
  
 +let max_int = (1 lsl 30) - 1  (* coerce-32bit.patch *)
 +
- [@@@ocaml.warning "-32-37"]
+ [@@@ocaml.warning "-37"]
  
  (** This file defines the mllambda code generation phase of the native
 diff --git a/kernel/uint63_31.ml b/kernel/uint63_31.ml
-index e8759ef..5045969 100644
+index 6f88edb..68a4d05 100644
 --- a/kernel/uint63_31.ml
 +++ b/kernel/uint63_31.ml
 @@ -11,7 +11,7 @@
@@ -69,10 +69,10 @@ index e8759ef..5045969 100644
  let uint_size = 63
  
 diff --git a/lib/objFile.ml b/lib/objFile.ml
-index a499b04..2aa0762 100644
+index 26c496c..ea8cd95 100644
 --- a/lib/objFile.ml
 +++ b/lib/objFile.ml
-@@ -138,7 +138,7 @@ let marshal_out_segment h ~segment v =
+@@ -113,7 +113,7 @@ let marshal_out_segment h ~segment v =
    let { out_channel = ch } = h in
    let () = assert (not (CString.Map.mem segment h.out_segments)) in
    let pos = LargeFile.pos_out ch in
@@ -82,10 +82,10 @@ index a499b04..2aa0762 100644
    let pos' = LargeFile.pos_out ch in
    let len = Int64.sub pos' pos in
 diff --git a/lib/system.ml b/lib/system.ml
-index b3dfee3..d01077d 100644
+index 3c0d1eb..9d403ad 100644
 --- a/lib/system.ml
 +++ b/lib/system.ml
-@@ -168,7 +168,7 @@ let check_caml_version ~caml:s ~file:f =
+@@ -230,7 +230,7 @@ let check_caml_version ~caml:s ~file:f =
      be compatible.")
    else ()
  
@@ -95,7 +95,7 @@ index b3dfee3..d01077d 100644
    try Marshal.from_channel ch
    with
 diff --git a/plugins/extraction/extract_env.ml b/plugins/extraction/extract_env.ml
-index a5c063e..f117b87 100644
+index 6fa1988..de1e535 100644
 --- a/plugins/extraction/extract_env.ml
 +++ b/plugins/extraction/extract_env.ml
 @@ -22,6 +22,8 @@ open Extraction
@@ -121,7 +121,7 @@ index 268d4bf..30ba948 100644
  
  exception Found
 diff --git a/plugins/ltac/tacentries.ml b/plugins/ltac/tacentries.ml
-index 4293160..bd46d25 100644
+index a823f87..3727997 100644
 --- a/plugins/ltac/tacentries.ml
 +++ b/plugins/ltac/tacentries.ml
 @@ -243,7 +243,7 @@ let make_fresh_key =
@@ -134,36 +134,23 @@ index 4293160..bd46d25 100644
      Lib.make_kn lbl
  
 diff --git a/plugins/micromega/coq_micromega.ml b/plugins/micromega/coq_micromega.ml
-index 8846b09..f6b3a6a 100644
+index ccd5c9c..ce991de 100644
 --- a/plugins/micromega/coq_micromega.ml
 +++ b/plugins/micromega/coq_micromega.ml
-@@ -26,6 +26,8 @@ open Constr
- open Context
+@@ -27,6 +27,8 @@ open Context
  open Tactypes
+ open McPrinter
  
 +let max_int = (1 lsl 30) - 1  (* coerce-32bit.patch *)
 +
  (**
    * Debug flag
    *)
-diff --git a/plugins/micromega/mfourier.ml b/plugins/micromega/mfourier.ml
-index f4d17b8..121384e 100644
---- a/plugins/micromega/mfourier.ml
-+++ b/plugins/micromega/mfourier.ml
-@@ -14,6 +14,8 @@ open Util
- open Polynomial
- open Vect
- 
-+let max_int = (1 lsl 30) - 1  (* coerce-32bit.patch *)
-+
- let debug = false
- let compare_float (p : float) q = pervasives_compare p q
- 
 diff --git a/plugins/micromega/persistent_cache.ml b/plugins/micromega/persistent_cache.ml
-index 6e99769..038190e 100644
+index 94c5329..1b68ca1 100644
 --- a/plugins/micromega/persistent_cache.ml
 +++ b/plugins/micromega/persistent_cache.ml
-@@ -180,7 +180,7 @@ module PHashtable (Key : HashedType) : PHashtable with type key = Key.t = struct
+@@ -160,7 +160,7 @@ module PHashtable (Key : HashedType) : PHashtable with type key = Key.t = struct
    let add t k e =
      let {outch} = t in
      let fd = descr_of_out_channel outch in
@@ -171,8 +158,8 @@ index 6e99769..038190e 100644
 +    let h = Key.hash k land 0x3FFFFFFF in
      let dump () =
        let () = output_binary_int outch h in
-       let pos = pos_out outch in
-@@ -193,7 +193,7 @@ module PHashtable (Key : HashedType) : PHashtable with type key = Key.t = struct
+       let () = Marshal.to_channel outch (k, e) [] in
+@@ -172,7 +172,7 @@ module PHashtable (Key : HashedType) : PHashtable with type key = Key.t = struct
  
    let find t k =
      let {outch; htbl = tbl} = t in
@@ -182,7 +169,7 @@ index 6e99769..038190e 100644
      (* First look for already live data *)
      let find data = match data.obj with
 diff --git a/plugins/micromega/polynomial.ml b/plugins/micromega/polynomial.ml
-index d68ea63..5dd7974 100644
+index 5586152..896e9e8 100644
 --- a/plugins/micromega/polynomial.ml
 +++ b/plugins/micromega/polynomial.ml
 @@ -19,6 +19,8 @@ open Q.Notations
@@ -195,24 +182,21 @@ index d68ea63..5dd7974 100644
  
  type var = int
 diff --git a/theories/Numbers/Cyclic/Int63/Ring63.v b/theories/Numbers/Cyclic/Int63/Ring63.v
-index 008d552..7b9f612 100644
+index 9ccf4cc..9584347 100644
 --- a/theories/Numbers/Cyclic/Int63/Ring63.v
 +++ b/theories/Numbers/Cyclic/Int63/Ring63.v
-@@ -61,9 +61,10 @@ Add Ring Uint63Ring : Uint63Ring
+@@ -61,7 +61,7 @@ Add Ring Uint63Ring : Uint63Ring
    constants [Uint63cst]).
  
  Section TestRing.
 -Let test : forall x y, 1 + x*y + x*x + 1 = 1*1 + 1 + y*x + 1*x*x.
-+Goal forall x y, 1 + x*y + x*x + 1 = 1*1 + 1 + y*x + 1*x*x.
++Goal test : forall x y, 1 + x*y + x*x + 1 = 1*1 + 1 + y*x + 1*x*x.
  intros. ring.
 -Qed.
-+(* Qed. *)
-+Admitted.
++(* Qed. *) Admitted.
  End TestRing.
- 
- #[deprecated(since="8.14",note="Use isUint63cst instead")]
 diff --git a/theories/Numbers/Cyclic/Int63/Uint63.v b/theories/Numbers/Cyclic/Int63/Uint63.v
-index 1ea47ed..20f7c8f 100644
+index 93d34a7..6f98541 100644
 --- a/theories/Numbers/Cyclic/Int63/Uint63.v
 +++ b/theories/Numbers/Cyclic/Int63/Uint63.v
 @@ -1110,8 +1110,8 @@ Proof.
@@ -227,7 +211,7 @@ index 1ea47ed..20f7c8f 100644
  Lemma addmuldiv_spec x y p :
    φ p <= φ digits  ->
 diff --git a/vernac/metasyntax.ml b/vernac/metasyntax.ml
-index 63f682e..071dc3b 100644
+index 7f80a52..56ad4c1 100644
 --- a/vernac/metasyntax.ml
 +++ b/vernac/metasyntax.ml
 @@ -26,6 +26,8 @@ open Libnames

--- a/etc/patches/fold.patch
+++ b/etc/patches/fold.patch
@@ -1,5 +1,5 @@
 diff --git a/vernac/declaremods.ml b/vernac/declaremods.ml
-index d10a358..7058e5f 100644
+index f4c98df..88b1cb5 100644
 --- a/vernac/declaremods.ml
 +++ b/vernac/declaremods.ml
 @@ -18,6 +18,9 @@ open Libnames
@@ -12,12 +12,12 @@ index d10a358..7058e5f 100644
  (** {6 Inlining levels} *)
  
  (** Rigid / flexible module signature *)
-@@ -607,7 +610,7 @@ let intern_args params =
+@@ -620,7 +623,7 @@ let check_sub mtb sub_mtb_l =
+     let _, cst = Subtyping.check_subtypes state env mtb sub_mtb in
+     (Univ.Constraints.union ocst cst, Environ.add_constraints cst env)
+   in
+-  let cst, _ = List.fold_right fold sub_mtb_l (Univ.Constraints.empty, Global.env ()) in
++  let cst, _ = list_fold_right_stackless fold sub_mtb_l (Univ.Constraints.empty, Global.env ()) in
+   Global.add_constraints cst
  
- let check_sub mtb sub_mtb_l =
-   (* The constraints are checked and forgot immediately : *)
--  ignore (List.fold_right
-+  ignore (list_fold_right_stackless
-             (fun sub_mtb env ->
-                Environ.add_constraints
-                  (Subtyping.check_subtypes env mtb sub_mtb) env)
+ (** This function checks if the type calculated for the module [mp] is

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jscoq",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jscoq",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "array-equal": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jscoq",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "A port of Coq to JavaScript -- run Coq in your browser",
   "bin": {
     "jscoq": "./dist/cli.js",

--- a/package.json.wacoq
+++ b/package.json.wacoq
@@ -1,6 +1,6 @@
 {
   "name": "wacoq",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "A port of Coq to WebAssembly -- run Coq in your browser",
   "bin": {
     "wacoqdoc": "ui-js/jscoqdoc.js"
@@ -25,7 +25,7 @@
     "path": "^0.12.7",
     "vue": "^2.6.12",
     "vue-context-menu": "^2.0.6",
-    "wacoq-bin": "0.15.1"
+    "wacoq-bin": "0.16.0"
   },
   "devDependencies": {
     "@types/find": "^0.2.1",


### PR DESCRIPTION
This is broken due to `load_plugin` not being implemented yet.

We need to think about how to fix that, likely just updating our
library manager to include `META` files for the plugins should work,
but we need to find out.

The main relevant change for us in Coq 8.16 is that Coq now loads
plugins using the `Fl_dynload` API.

So now Coq, will make a request for `coq-core.plugins.ltac` instead of
`ltac_plugin.cma`.

`Fl_dynload` is a wrapper over `Dynlink.loadfile`, but will check
`META` files for dependencies, and if plugins `A` depends on `B`, will
load `B` first.

This may be a problem for us, we need to figure how to handle
that.

One approach couuld be to replace the `Dynlink.dynload` stub with the
proper javascript implementation so the `Fl_dynload` uses it implicitly.

Another (temporal) alternative to get this working is just to ignore
deps and implement `Ml_top.load_plugin` with a mapping. I have done
that as Coq 8.16 still includes a "legacy" mode, which should work for
some plugins, but not for all of them (coq-elpi for example requires this).

The 3rd approach would be for us to reimplement `Fl_dynload` by
locating the META files and parsing them, or storing this metadata in
some other fashion.