### PR TITLE
[js] [refactor] Remove use of JsCoq global in components.

### DIFF
--- a/ui-js/coq-layout-classic.js
+++ b/ui-js/coq-layout-classic.js
@@ -103,7 +103,7 @@ export class CoqLayoutClassic {
         this.panel = document.createElement('div');
         this.panel.id = 'panel-wrapper';
         this.panel.innerHTML = this.html({base_path: options.base_path,
-            backend: JsCoq.backend, ...params});
+            backend: this.options.backend, ...params});
 
         this.ide.appendChild(this.panel);
 

--- a/ui-js/headless.ts
+++ b/ui-js/headless.ts
@@ -25,7 +25,8 @@ class HeadlessCoqWorker extends CoqWorker {
     options: any
 
     constructor() {
-        super(null, HeadlessCoqWorker.instance());
+        var backend = 'js', is_npm = 'false';
+        super(null, HeadlessCoqWorker.instance(), backend, is_npm);
         this.when_created.then(() => {
             this.worker.onmessage = this._handler = evt => {
                 process.nextTick(() => this.coq_handler({data: evt}));

--- a/ui-js/index.js
+++ b/ui-js/index.js
@@ -15,9 +15,8 @@ const JsCoq = {
     is_npm: false,  /* indicates that jsCoq was installed via `npm install` */
 
     load(...args) {
-        let opts = this._getopt('load', ...args),
-            {base_path, node_modules_path} = opts;
-        return this._load(base_path, node_modules_path).then(() => opts);
+        let { jscoq_ids, jscoq_opts } = this._getopt('load', ...args);
+        return this._load(jscoq_opts.base_path, jscoq_opts.node_modules_path).then(() => opts);
     },
 
     _load(base_path, node_modules_path) {
@@ -29,11 +28,9 @@ const JsCoq = {
     },
 
     async start(...args) {
-        let opts = this._getopt('start', ...args),
-            {base_path, node_modules_path, jscoq_ids, jscoq_opts} = opts;
-        this.backend = jscoq_opts.backend || this.backend;
-        await this._load(base_path, node_modules_path);
-        return new CoqManager(jscoq_ids, jscoq_opts)
+        let { jscoq_ids, jscoq_opts } = this._getopt('start', ...args);
+        await this._load(jscoq_opts.base_path, jscoq_opts.node_modules_path);
+        return new CoqManager(jscoq_ids, jscoq_opts);
     },
 
     /**
@@ -45,12 +42,15 @@ const JsCoq = {
      *  * (string[]) elements ids / CSS selectors designating interactive snippets
      *  * (object) options object passed to `CoqManager` (see `coq-manager.js`)
      * All arguments are optional. Assignment is done according to type.
-     * @returns 
+     * @returns
      */
     _getopt(method, ...args) {
-        var base_path = undefined, node_modules_path = undefined,
-            jscoq_ids = ['ide-wrapper'], jscoq_opts = {};
-        
+
+        var base_path = undefined,
+            node_modules_path = undefined,
+            jscoq_ids = ['ide-wrapper'],
+            jscoq_opts = {};
+
         // Interpret args according to spec, skip missing values
         if (typeof args[0] === 'string') base_path = args.shift();
         if (typeof args[0] === 'string') node_modules_path = args.shift();
@@ -59,14 +59,16 @@ const JsCoq = {
 
         if (args.length > 0) console.warn(`too many arguments to JsCoq.${method}()`);
 
-        // Set base and node_modules path from options if not given, use defaults
-        base_path ||= jscoq_opts.base_path || this.base_path;
-        jscoq_opts.base_path ||= base_path;
-        node_modules_path ||= jscoq_opts.node_modules_path || 
-                              base_path + (this.is_npm ? "../" : "node_modules/");
-        jscoq_opts.node_modules_path ||= node_modules_path;
+        // Backend setup
+        jscoq_opts.backend = jscoq_opts.backend || this.backend;
 
-        return {base_path, node_modules_path, jscoq_ids, jscoq_opts}
+        // Set base and node_modules path from options if not given, use defaults
+        jscoq_opts.base_path = base_path || jscoq_opts.base_path || this.base_path;
+        jscoq_opts.node_modules_path = node_modules_path
+                                    || jscoq_opts.node_modules_path
+                                    || jscoq_opts.base_path + (this.is_npm ? "../" : "node_modules/");
+
+        return {jscoq_ids, jscoq_opts}
     },
 
     globalConfig(v) {
@@ -131,5 +133,8 @@ function whenReady() {
                 document.readyState === 'complete' && r()));
 }
 
-
 export { JsCoq, CoqManager }
+
+// Local Variables:
+// js-indent-level: 4
+// End:


### PR DESCRIPTION
Instead of using a JsCoq global, we pass the needed parameters to the
constructors so the components types are more functional.

The access to the global was mostly used to determine the backend, but
IMHO this is morally wrong as nothing should preclude a manager
creating N worker objects with different backends.

Moreover, most of the backend case analysis should go away once we
improve backend handling.

This is also a step towards frontend / backend separation.

Next step is indeed to isolate the backend options in their own
interface.