### PR TITLE
[build] Bump Dune to >= 3.5.0

### DIFF
--- a/dune
+++ b/dune
@@ -18,16 +18,12 @@
 
 (rule
  (targets (dir node_modules))
+ (mode (promote (until-clean)))
  (deps
-   (sandbox always)
    package.json
    package-lock.json)
  (action
-  (progn
-   (run npm install --no-save)
-   ; Otherwise Dune says `Error: Rule produced a file with unrecognised kind "S_LNK"`
-   ; https://github.com/ocaml/dune/issues/5945
-   (run find node_modules -type l -exec rm {} ";"))))
+  (run npm install --no-save)))
 
 (alias
  (name jscoq)
@@ -57,9 +53,11 @@
   dist))
 
 ; JavaScript build (Webpack)
-; cli.cjs, ide-project.browser.js, collab.browser.js
+; Emilio: do we want to list individual files inside dist here or keep
+; the directory as a target?
 (rule
- (target dist)
+ (target (dir dist))
+ (mode (promote (until-clean)))
  (deps
   (source_tree backend)
   (source_tree frontend)
@@ -67,11 +65,7 @@
   tsconfig.json
   node_modules)
  (action
-  (progn
-   (run npm install --no-save) ; sorry, have to run this again because of the symlinks I erased before *facepalm*
-   (run npm run build))))
-   ; XXX: setup this to add :dev when the debug env var is set
-   ;(run npm run build:dev))))
+  (run npm run %{env:NPM_TARGET=build})))
 
 ; Just the worker
 (alias
@@ -84,5 +78,5 @@
   (deps
     backend/wasm/wacoq_worker.bc))
 
-(dirs (:standard _vendor+* \ dist node_modules))
+(dirs (:standard _vendor+*))
 (vendored_dirs vendor)

--- a/jscoq.opam
+++ b/jscoq.opam
@@ -12,7 +12,7 @@ doc:          "https://github.com/jscoq/jscoq#readme"
 
 depends: [
   "ocaml"               { >= "4.12.0"           }
-  "dune"                { >= "3.3.1" & < "3.4"  }
+  "dune"                { >= "3.5.0"            }
   "js_of_ocaml"         { >= "4.0.0" & < "5"    }
   "js_of_ocaml-ppx"     { >= "4.0.0" & < "5"    }
   "js_of_ocaml-lwt"     { >= "4.0.0" & < "5"    }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+import os from 'os';
 import webpack from 'webpack';
 import fs from 'fs';
 import path from 'path';
@@ -7,8 +8,9 @@ import { VueLoaderPlugin } from 'vue-loader';
 import TerserPlugin from 'terser-webpack-plugin';
 
 const __dirname = path.resolve('.'),
+      __tmpdir = path.resolve(os.tmpdir()),
       require = createRequire(import.meta.url);
-  
+
 const
   basics = (argv) => ({
     mode: 'development',
@@ -16,7 +18,10 @@ const
     stats: {
       hash: false, version: false, modules: false  // reduce verbosity
     },
-    cache: { type: 'filesystem' },
+    cache: {
+      type: 'filesystem',
+      cacheDirectory: path.resolve(__tmpdir, '.webpack_cache')
+    },
     performance: {
       maxAssetSize: 1e6, maxEntrypointSize: 1e6   // 250k is too small
     }


### PR DESCRIPTION
This fixes the directory target rule problem.

Thanks to Rudi Grinberg!

Dune 3.5.0 is not released yet, but it is expected before the end of the week.