### PR TITLE
Towards `require.resolve`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "prettier.enable": false,
+  "editor.formatOnSave": false
+}

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ all:
 	@echo "Welcome to jsCoq makefile. Targets are:"
 	@echo ""
 	@echo "     jscoq: build jsCoq [JavaScript and libraries]"
-	@echo "     wacoq: build waCoq [JavaScript, frontend only; depends on wacoq-bin]"
+	@echo "     wacoq: build waCoq [JavaScript, frontend only]"
 	@echo ""
 	@echo "     links: create links that allow to serve pages from the source tree"
 	@echo ""

--- a/backend/coq-worker.ts
+++ b/backend/coq-worker.ts
@@ -514,12 +514,6 @@ export class CoqWorker {
  */
 export class CoqSubprocessAdapter extends CoqWorker {
     constructor(base_path, backend, is_npm) {
-        /* Emilio: the require here fails, this is a fixme!
-        const subproc = require('wacoq-bin/dist/subproc'),
-              icoq = new subproc.IcoqSubprocess();
-        super(base_path, null, icoq, backend, is_npm);
-        window.addEventListener('beforeunload', () => icoq.end());
-        */
        super(base_path, null, null, backend, is_npm);
     }
 

--- a/backend/wasm/wacoq_worker.ts
+++ b/backend/wasm/wacoq_worker.ts
@@ -9,7 +9,7 @@ function postMessage(msg) {
 
 async function main() {
     /** @note when serving from source tree, the `node_modules` ref works by chance */
-    var icoq = new IcoqPod('../backend/wasm', '../../../node_modules');
+    var icoq = new IcoqPod('../backend/wasm');
 
     postMessage(['Starting']);
     icoq.on('message', postMessage);

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -207,28 +207,10 @@ ARG WASI_SDK_URL="https://github.com/WebAssembly/wasi-sdk/releases/download/wasi
 RUN wget -O/tmp/wasi-sdk.tar.gz ${WASI_SDK_URL}
 RUN ( cd /opt && tar xf /tmp/wasi-sdk.tar.gz && ln -s wasi-sdk-* wasi-sdk )
 
-# ---------------------
-# waCoq toolchain setup
-# ---------------------
-FROM wacoq-preinstall as wacoq-prereq
-
-ARG BRANCH
-ARG WACOQ_BIN_REPO=https://github.com/jscoq/wacoq-bin.git
-ARG WACOQ_BIN_BRANCH=${BRANCH}
-
-WORKDIR /root
-RUN git clone --recursive -b ${WACOQ_BIN_BRANCH} ${WACOQ_BIN_REPO} wacoq-bin
-
-WORKDIR wacoq-bin
-RUN opam update
-RUN ./etc/setup.sh
-RUN opam clean -a -c
-RUN opam list
-
 # -----------------
 # waCoq+jsCoq build
 # -----------------
-FROM wacoq-prereq as wacoq
+FROM wacoq-preinstall as wacoq
 
 ARG BRANCH
 ARG JSCOQ_REPO=https://github.com/jscoq/jscoq.git
@@ -245,7 +227,6 @@ WORKDIR /root
 RUN git clone --recursive -b ${JSCOQ_BRANCH} ${JSCOQ_REPO} jscoq+wacoq
 
 WORKDIR jscoq+wacoq
-RUN cp ../wacoq-bin/wacoq-bin-*.tar.gz . && npm install ./wacoq-bin-*.tar.gz
 RUN npm install
 RUN make wacoq
 RUN make dist-npm-wacoq

--- a/etc/docker/Makefile
+++ b/etc/docker/Makefile
@@ -7,9 +7,6 @@ BRANCH = v8.16
 export JSCOQ_REPO = https://github.com/$(WHO)/jscoq.git
 export JSCOQ_BRANCH = $(BRANCH)
 
-export WACOQ_BIN_REPO = https://github.com/$(WHO)/wacoq-bin.git
-export WACOQ_BIN_BRANCH = $(BRANCH)
-
 export NJOBS ?= 4
 
 M := ${shell uname -m}
@@ -24,7 +21,7 @@ endif
 export DOCKER_BUILDKIT = 1
 
 BUILD_ARGS = BRANCH SUB_BRANCH NJOBS WORDSIZE \
-             JSCOQ_REPO JSCOQ_BRANCH WACOQ_BIN_REPO WACOQ_BIN_BRANCH
+             JSCOQ_REPO JSCOQ_BRANCH
 
 ARGS = $(addprefix --platform , $(firstword ${ARCH})) \
        $(addprefix --build-arg , $(BUILD_ARGS))

--- a/frontend/cli/build/sdk/setup.ts
+++ b/frontend/cli/build/sdk/setup.ts
@@ -15,8 +15,7 @@ const ME = 'jscoq',
       SDK = `/tmp/${ME}-sdk`,
       SDK_FLAGS = (process.env['JSCOQ'] || '').split(',').filter(x => x);
 
-const DEFAULT_PKGS_LOCATION = ['jscoq/coq-pkgs', 'wacoq-bin/bin/coq']
-
+const DEFAULT_PKGS_LOCATION = 'jscoq/coq-pkgs'
 
 async function setup(basedir = SDK, includeNative = true) {
     mkdirp.sync(basedir);

--- a/frontend/cli/build/sdk/setup.ts
+++ b/frontend/cli/build/sdk/setup.ts
@@ -1,9 +1,7 @@
 // UNTIL THIS IS MERGED INTO THE CLI:
 //   tsc --allowSyntheticDefaultImports --esModuleInterop bin/sdk.ts
-import fs from 'fs';
 import path from 'path';
 import mkdirp from 'mkdirp';
-import findUp from 'find-up';
 import glob from 'glob';
 import unzip from 'fflate-unzip';
 import chld from 'child-process-promise';
@@ -15,18 +13,16 @@ const ME = 'jscoq',
       SDK = `/tmp/${ME}-sdk`,
       SDK_FLAGS = (process.env['JSCOQ'] || '').split(',').filter(x => x);
 
-const DEFAULT_PKGS_LOCATION = 'jscoq/coq-pkgs'
+const DEFAULT_PKGS_LOCATION = path.join(__dirname, '../coq-pkgs');
 
 async function setup(basedir = SDK, includeNative = true) {
     mkdirp.sync(basedir);
 
     // Locate `coq-pkgs`
     var flag = SDK_FLAGS.map(s => s.match(/^coq-pkgs=(.*)$/)?.[1]).filter(x => x),
-        nm = findNM(),
         coqpkgsDir: string;
     for (let sp of flag.concat(DEFAULT_PKGS_LOCATION)) {
-        var fp = path.join(nm, sp);
-        if (existsDir(fp)) { coqpkgsDir = fp; break; }
+        if (existsDir(sp)) { coqpkgsDir = sp; break; }
     }
     if (!coqpkgsDir) throw {err: "Package bundles (*.coq-pkg) not found"};
 
@@ -74,12 +70,6 @@ async function runCoqC(cfg: {coqlib: string, include: string},
 }
 
 /*- specific helpers -*/
-
-function findNM() {
-    var nm = findUp.sync('node_modules', {type: 'directory'});
-    if (!nm) throw {err: "node_modules directory not found"};
-    return nm;
-}
 
 async function findCoq() {
     var cfg = await chld.exec("coqc -config"),

--- a/frontend/cli/build/sdk/setup.ts
+++ b/frontend/cli/build/sdk/setup.ts
@@ -25,7 +25,6 @@ async function setup(basedir = SDK, includeNative = true) {
         nm = findNM(),
         coqpkgsDir: string;
     for (let sp of flag.concat(DEFAULT_PKGS_LOCATION)) {
-        if (existsDir(sp)) { coqpkgsDir = sp; break; }
         var fp = path.join(nm, sp);
         if (existsDir(fp)) { coqpkgsDir = fp; break; }
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,7 +83,6 @@ const
 export default (env, argv) => [
 /**
  * jsCoq CLI
- * (note: the waCoq CLI is located in package `wacoq-bin`)
  */
 {
   name: 'cli',
@@ -96,7 +95,6 @@ export default (env, argv) => [
   externals: [
     {  /* do not bundle the worker */
       '../backend/jsoo/jscoq_worker.bc.cjs': 'commonjs2 ../backend/jsoo/jscoq_worker.bc.cjs',
-      'wacoq-bin/dist/subproc': 'undefined',
       'cross-spawn': 'commonjs2 cross-spawn'
     },
     /* filter out browser-only modules */
@@ -123,7 +121,7 @@ export default (env, argv) => [
     minimizer: [
       new TerserPlugin({  /* this is a hack because Ronin's Syncpad checks the class name */
         terserOptions: { keep_fnames: /^CodeMirror$/ }
-      })  
+      })
     ]
   },
   experiments: {
@@ -193,7 +191,6 @@ export default (env, argv) => [
   },
   externals: {
     fs: 'commonjs2 fs', child_process: 'commonjs2 child_process',
-    'wacoq-bin/dist/subproc': 'commonjs2'
   },
   module: {
     rules: [ts, css, scss, imgs, vuesfc]


### PR DESCRIPTION
Hi,

I've removed mentions of `node_modules` in `core.ts`. However, I have a question about `setup.ts`: why are there two codepaths? Will `jscoq` and `wacoq-bin` ever be present in `node_modules`?

Thanks.