### PR TITLE
Dockerfile: fix build since f67e5e27

### DIFF
--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -91,7 +91,7 @@ RUN eval $(opam env) && make wacoq
 
 # - dist tarballs
 RUN eval $(opam env) && make dist \
-        && mkdir dist && mv _build/dist/*.tgz dist
+        && mkdir -p dist && mv _build/dist/*.tgz dist
 
 # --------------
 # Addon packages


### PR DESCRIPTION
f67e5e27 modifies the dist rule in the Makefile, so that the Dockerfile no longer needs to do anything more than `make dist`.