### PR TITLE
Ensure jsCoq can be loaded from a cross-origin CDN such as jsDelivr (issue #356)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,52 @@ See the [Troubleshooting](#Troubleshooting) section if you have problems.
 
 jsCoq is community-developed by a [team of contributors](#Credits).
 
+## Quick start
+
+The following template allows you to get quickly started with jsCoq, while the
+necessary resources are loaded from an external content delivery network (jsDelivr):
+
+```
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="content-type" content="text/html;charset=utf-8" />
+  <title>Getting started with jsCoq</title>
+  <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/jscoq@0.17.2/dist/frontend/index.css">
+</head>
+<body class="jscoq-main">
+  <div id="ide-wrapper" class="toggled">
+    <div id="code-wrapper">
+      <div id="document">
+        <h1>Welcome to your own jsCoq development</h1>
+        <p>
+            Want to create a document like this one?
+            Copy <tt>node_modules/jscoq/examples/npm-template.html</tt>
+            and start editing.
+        </p>
+        <textarea class="coq-code">
+(* Your document can embed Coq snippets! *)
+Inductive and_they_run := too(*!*).
+</textarea>
+      </div>
+    </div>
+  </div>
+  <!-- jsCoq configuration part -->
+  <script type="module">
+    import { JsCoq } from 'https://cdn.jsdelivr.net/npm/jscoq@0.17.2/jscoq.js';
+    var jscoq_ids  = ['.coq-code'];
+    var jscoq_opts = {
+        prelude:       true,
+        implicit_libs: true,
+        editor:        { mode: { 'company-coq': true } },
+        init_pkgs:     ['init'],
+        all_pkgs:      ['coq']
+    };
+    JsCoq.start(jscoq_ids, jscoq_opts);
+  </script>
+</body>
+```
+
 ## Are you a jsCoq user?
 
 Have you developed or taught a course **using jsCoq**? Do you have some feedback for us?

--- a/backend/coq-worker.ts
+++ b/backend/coq-worker.ts
@@ -147,7 +147,8 @@ export class CoqWorker {
         // BUG #352: Ensure that the Web Worker construction does not lead to a SecurityError,
         // even when the url is not same-origin, but cross-origin (e.g. jsCoq is hosted by a CDN).
         // See also: https://stackoverflow.com/questions/21913673/execute-web-worker-from-different-origin
-        const content = `importScripts("${JSON.stringify(url)}");`;
+        const content = `importScripts("${JSON.stringify(url.toString())}");`;
+        console.log(content);
         const url_blob = URL.createObjectURL(new Blob([content], {type: "text/javascript"}));
         return new Worker(url_blob);
         URL.revokeObjectURL(url_blob);

--- a/backend/coq-worker.ts
+++ b/backend/coq-worker.ts
@@ -147,7 +147,7 @@ export class CoqWorker {
         // BUG #352: Ensure that the Web Worker construction does not lead to a SecurityError,
         // even when the url is not same-origin, but cross-origin (e.g. jsCoq is hosted by a CDN).
         // See also: https://stackoverflow.com/questions/21913673/execute-web-worker-from-different-origin
-        const content = `importScripts("${JSON.stringify(url.toString())}");`;
+        const content = `importScripts(${JSON.stringify(url.toString())});`;
         console.log(content);
         const url_blob = URL.createObjectURL(new Blob([content], {type: "text/javascript"}));
         return new Worker(url_blob);

--- a/docs/npm-landing.html
+++ b/docs/npm-landing.html
@@ -3,6 +3,7 @@
   <head>
     <meta http-equiv="content-type" content="text/html;charset=utf-8" />
     <title>jsCoq NPM package</title>
+    <link rel="stylesheet" type="text/css" href="./dist/frontend/index.css">
   </head>
 
 <body class="jscoq-main">

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -64,7 +64,7 @@ FROM jscoq-preinstall as jscoq-prereq
 
 ARG BRANCH
 ARG WORDSIZE
-ARG JSCOQ_REPO=https://github.com/jscoq/jscoq
+ARG JSCOQ_REPO=https://github.com/praalhans/jscoq
 ARG JSCOQ_BRANCH=${BRANCH}
 
 WORKDIR /root

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -64,7 +64,7 @@ FROM jscoq-preinstall as jscoq-prereq
 
 ARG BRANCH
 ARG WORDSIZE
-ARG JSCOQ_REPO=https://github.com/praalhans/jscoq
+ARG JSCOQ_REPO=https://github.com/jscoq/jscoq
 ARG JSCOQ_BRANCH=${BRANCH}
 
 WORKDIR /root

--- a/etc/docker/Makefile
+++ b/etc/docker/Makefile
@@ -72,8 +72,8 @@ clean-dist:
 js-dist: clean-dist
 	docker run --name jscoq-get-dist jscoq:addons \
 		sh -c 'mkdir -p dist && cp _build/jscoq+*/*.tgz dist'
-	docker cp --quiet jscoq-get-dist:/root/jscoq/dist .
-	docker cp --quiet jscoq-get-dist:/root/jscoq-addons/dist .
+	docker cp jscoq-get-dist:/root/jscoq/dist .
+	docker cp jscoq-get-dist:/root/jscoq-addons/dist .
 	docker rm jscoq-get-dist
 
 wa-dist: clean-dist
@@ -86,7 +86,7 @@ wa-dist: clean-dist
 # For getting just the jsCoq package, w/o addons
 js-dist-core: clean-dist
 	docker run --name jscoq-get-dist jscoq
-	docker cp --quiet jscoq-get-dist:/root/jscoq/dist .
+	docker cp jscoq-get-dist:/root/jscoq/dist .
 	docker rm jscoq-get-dist
 
 # For updating the dist with the result of incremental build

--- a/frontend/classic/js/coq-layout-classic.ts
+++ b/frontend/classic/js/coq-layout-classic.ts
@@ -66,8 +66,8 @@ export class CoqLayoutClassic {
     <div id="toolbar">
       <div class="exits">
         <a href="https://coq.now.sh">
-          <img class="${backend}-logo" src="${base_path}/frontend/classic/images/${backend}-logo.svg" alt="js"><i>+</i><!--
-            --><img class="coq-logo" src="${base_path}/frontend/classic/images/coq-logo.png" alt="Coq">
+          <img class="${backend}-logo" src="${base_path}frontend/classic/images/${backend}-logo.svg" alt="js"><i>+</i><!--
+            --><img class="coq-logo" src="${base_path}frontend/classic/images/coq-logo.png" alt="Coq">
         </a>
       </div> <!-- /.exits -->
       <span id="buttons">
@@ -242,7 +242,7 @@ export class CoqLayoutClassic {
             image = $(this.proof).find('.splash-image'),
             below = $(this.proof).find('.splash-below');
 
-        var overlay = `${this.options.base_path}/frontend/classic/images/${mode}.gif`;
+        var overlay = `${this.options.base_path}frontend/classic/images/${mode}.gif`;
 
         if (!(above.length && image.length && below.length)) {
             $(this.proof).empty().append(
@@ -272,7 +272,7 @@ export class CoqLayoutClassic {
                 <a href="#scratchpad"><img>Scratchpad</a>
             </p>`);
         // Set icons
-        let icon = fn => `${this.options.base_path}/frontend/classic/images/${fn}`;
+        let icon = fn => `${this.options.base_path}frontend/classic/images/${fn}`;
         bar.find('a[href="#quick-help"] img').attr('src', icon('help.svg')).height("1em");
         bar.find('a[href="#scratchpad"] img').attr('src', icon('scratchpad.png')).height("1em");
         // Set quick-help action
@@ -457,7 +457,7 @@ export class CoqLayoutClassic {
      * Auxiliary function to improve UX by preloading images.
      */
     _preloadImages() {
-        var imgs_dir = `${this.options.base_path}/frontend/classic/images`,
+        var imgs_dir = `${this.options.base_path}frontend/classic/images`,
             img_fns = ['jscoq-splash.png', 'egg.png'];
 
         for (let fn of img_fns) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.17.1",
   "type": "module",
   "description": "A port of Coq to JavaScript -- run Coq in your browser",
-  "main": "frontend/classic/js/index.js",
+  "main": "jscoq.js",
   "browser": {
     "path": "path-browserify",
     "stream": "stream-browserify",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.17.1",
   "type": "module",
   "description": "A port of Coq to JavaScript -- run Coq in your browser",
-  "main": "jscoq.js",
+  "main": "dist/frontend/index.js",
+  "style": "dist/frontend/index.css",
   "browser": {
     "path": "path-browserify",
     "stream": "stream-browserify",


### PR DESCRIPTION
The comments have performed the following changes:

Major changes:
- The most important fix is to eliminate the SecurityError that is raised when the base URL from which jsCoq is loaded is not on the same origin as the page in which it is embedded. This is done by creating a blob, from which the cross-origin URL is loaded. It was checked that the behavior for same-origin still remains the same.
- Removes redundant slashes from resources that would otherwise not load from a CDN that is very strict in handling paths. Note that CDNs are likely to be strict with path handling to increase efficiency of handling requests.
- Adds new documentation in the main README how to embed jsCoq on any webpage, using the jsDelivr CDN, to get started quickly.

Minor changes:
- Removes `--quiet` flag from the `docker` command that did not work.
- Properly documents the main files in the `package.json` that need to be included on any page that wants to use jsCoq.
- Adds the default style sheet in the NPM template (that becomes `index.html` in the final NPM package). Note that the chosen path is in the current directory, so that the file can be used after a successful build. The comment  This commit may be redundant with pull request https://github.com/jscoq/jscoq/pull/353 Note that the latter pull request uses the prefix `./node_modules/jscoq`, which requires that jscoq is in the node_modules directory. (It should never be the case that jscoq is in its own node_modules directory.)

All changes have been tested by building the package by using the project's Dockerfile. The quick start example in the README (forward) references version 0.17.2, so that the example is already up-to-date for the next release, and allows users to quickly get started with jsCoq.