### PR TITLE
[build] `make serve` now properly sets headers so `SharedArrayBuffer` works

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@
  - Bump docker build action to v6 (@ejgallego, #368)
  - Streamline Docker build (@ejgallego, #367)
  - Bump Debian base Docker to Debian 12 (@ejgallego, #370)
+ - `make serve` now properly sets headers so
+   `window.crossOriginIsolated` holds, this is required on modern
+   browsers for `SharedArrayBuffer` support (@ejgallego, #371)
 
 # jsCoq 0.17.1 "Night slip"
 ---------------------------

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ watch: DUNE_FLAGS+=--watch
 watch: jscoq
 
 serve:
-	npx http-server $(BUILDDIR) -p 8013 -c 0
+	npx serve -c ../../etc/serve.json -C -l 8013 $(BUILDDIR)
 
 dev:
 	$(MAKE) serve &

--- a/etc/docker/Makefile
+++ b/etc/docker/Makefile
@@ -112,7 +112,7 @@ serve:
 		sh -c "cd _build/dist && npm i && npx -y static-server -p 8080"
 
 dist-serve:
-	npx http-server -p 8080 dist
+	npx serve -C -l 8080 dist
 
 ci:
 	make clean && make js-build && make dist

--- a/etc/serve.json
+++ b/etc/serve.json
@@ -1,0 +1,16 @@
+{
+  "headers": [
+    {
+      "source": "*",
+      "headers": [
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        },
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "require-corp"
+        }]
+    }
+  ]
+}


### PR DESCRIPTION
Note this required a change from npm `http-server` to more modern `serve` package.