### PR TITLE
[build] [js] Update to jsoo 5.9.1 from 4.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,27 @@
+# jsCoq 1.99.1
+--------------
+
+ - Port jsCoq backend to Flèche (@ejgallego, @corwin-of-amber)
+ - Port jsCoq frontend to TypeScript (@ejgallego, @corwin-of-amber)
+ - Use coq-lsp info view (which in turn descends from jsCoq's)
+   (@ejgallego, @corwin-of-amber)
+ - Have Docker CI use the PR branch on PR CI (@ejgallego, #321)
+ - Adapt `dist` targets and Docker build to new setup, note this
+   removes the wasm build from Docker as we are now unified.
+   (@ejgallego, #334)
+ - Bump node from 16 to 22 LTS (@ejgallego, #369)
+ - Bump docker build action to v6 (@ejgallego, #368)
+ - Streamline Docker build (@ejgallego, #367)
+ - Bump Debian base Docker to Debian 12 (@ejgallego, #370)
+ - `make serve` now properly sets headers so
+   `window.crossOriginIsolated` holds, this is required on modern
+   browsers for `SharedArrayBuffer` support (@ejgallego, #371)
+ - replace `Future` by `Promise` in `coq-worker`, this brings the
+   backend closer to JSON-RPC libs (@ejgallego, #376)
+ - Bump to jsoo 5.9.1, many many thanks to Hugo Heuzard (@ejgallego,
+   @hhugo, #372)
+ - Bump to yojson 3.0.0, dune 3.16 (@ejgallego, #372)
+
 # jsCoq 0.17.1 "Night slip"
 ---------------------------
 

--- a/backend/common/jscoq_interp.ml
+++ b/backend/common/jscoq_interp.ml
@@ -148,8 +148,8 @@ let init_workspace ~token ~dir opts =
   let vo_load_path = mk_vo_path opts.lib_path in
   let cmdline = Coq.Workspace.CmdLine.
       { coqlib = "/lib"
-      ; findlib_config = None
-      ; ocamlpath = ["/lib"]
+      ; findlib_config = Some "/lib/findlib.conf"
+      ; ocamlpath = []
       ; args = ["-boot"]
       ; require_libraries = []
       ; vo_load_path

--- a/backend/jsoo/dune
+++ b/backend/jsoo/dune
@@ -9,8 +9,8 @@
     js_stub/coq_vm.js
     js_stub/interrupt.js
     marshal-arch.js)
-  (flags :standard (:include .extraflags) --dynlink +dynlink.js +toplevel.js --setenv PATH=/bin))
- (link_flags -linkall -no-check-prims)
+  (flags :standard (:include .extraflags) --linkall +dynlink.js +toplevel.js --setenv PATH=/bin))
+ (link_flags -no-check-prims)
  ; The old makefile set: -noautolink -no-check-prims
  (libraries zarith_stubs_js jscoq_core js_of_ocaml-lwt))
 

--- a/backend/jsoo/js_stub/unix.js
+++ b/backend/jsoo/js_stub/unix.js
@@ -479,6 +479,9 @@ function unix_spawn()                 { unix_ll("unix_spawn", arguments); }
 // Provides: unix_fsync
 // Requires: unix_ll
 function unix_fsync()                 { unix_ll("unix_fsync", arguments); }
+// Provides: unix_realpath
+// Requires: unix_ll
+function unix_realpath()                 { unix_ll("unix_realpath", arguments); }
 // Provides: unix_inchannel_of_filedescr
 // Requires: unix_ll
 function unix_inchannel_of_filedescr()  { unix_ll("unix_inchannel_of_filedescr", arguments); }

--- a/backend/jsoo/jscoq_worker.ml
+++ b/backend/jsoo/jscoq_worker.ml
@@ -25,8 +25,6 @@ let rec json_to_obj (cobj : < .. > Js.t) (json : Yojson.Safe.t) : < .. > Js.t =
   | `String s -> coerce @@ Js.string s
   | `Int m    -> coerce @@ Js.number_of_float (Obj.magic m)
   | `Intlit s -> coerce @@ Js.number_of_float (float_of_string s)
-  | `Tuple t  -> Array.(Js.array @@ map ofresh (of_list t))
-  | `Variant(_,_) -> pure_js_expr "undefined"
 
 let rec obj_to_json (cobj : < .. > Js.t) : Yojson.Safe.t =
   let open Js in

--- a/backend/jsoo/jslibmng.ml
+++ b/backend/jsoo/jslibmng.ml
@@ -191,9 +191,7 @@ let coq_cma_link ~file_path =
     let js_code =
       try (Hashtbl.find file_cache cmo_file).file_content
       with Not_found -> Sys_js.read_file ~name:(cmo_file ^ ".js") in
-    let js_code =
-      if String.sub js_code 0 1 = "(" then js_code 
-      else "(" ^ js_code ^ ")" (* jsoo < 4.0 *) in
+    let js_code = Format.asprintf "(function (globalThis) { @[%s@] })" js_code in
     (* When eval'ed, the js_code will return a closure waiting for the
        jsoo global object to link the plugin.
     *)

--- a/examples/sdk-demo/dune-project
+++ b/examples/sdk-demo/dune-project
@@ -1,2 +1,2 @@
-(lang dune 3.1)
-(using coq 0.2)
+(lang dune 3.16)
+(using coq 0.8)

--- a/frontend/cli/build/project.ts
+++ b/frontend/cli/build/project.ts
@@ -596,7 +596,7 @@ class JsCoqCompat {
             const infile = mod.physical, outfile = `${infile}.js`,
                   flags = JsCoqCompat.flags();
             // assumes volume is fsif_native...
-            child_process.execSync(`js_of_ocaml ${flags} --wrap-with-fun= -o ${outfile} ${infile}`);
+            child_process.execSync(`js_of_ocaml ${flags} --dynlink -o ${outfile} ${infile}`);
             return [mod, /*{...mod, payload: new Uint8Array(*empty*)},*/
                     {...mod, physical: outfile, ext: '.cma.js'}];
         }

--- a/jscoq.opam
+++ b/jscoq.opam
@@ -13,10 +13,10 @@ doc:          "https://github.com/jscoq/jscoq#readme"
 depends: [
   "ocaml"               { >= "4.12.0"           }
   "dune"                { >= "3.16"             }
-  "js_of_ocaml"         { >= "5.8.0" & < "6.0"  }
-  "js_of_ocaml-ppx"     { >= "5.8.0" & < "6.0"  }
-  "js_of_ocaml-lwt"     { >= "5.8.0" & < "6.0"  }
-  "yojson"              { >= "2.0.2"            }
+  "js_of_ocaml"         {  = "5.9.1"            }
+  "js_of_ocaml-ppx"     {  = "5.9.1"            }
+  "js_of_ocaml-lwt"     {  = "5.9.1"            }
+  "yojson"              { >= "3.0.0"            }
   "ppx_deriving_yojson" { >= "3.5.3"            }
   "ppx_import"          { >= "1.11.0"           }
   "lwt_ppx"             { >= "2.0.1"            }


### PR DESCRIPTION
Note that we now link `js_of_ocaml-compiler.dynlink` which pulls
`js_of_ocaml-compiler` and `compiler-libs.bytecomp`.