### PR TITLE
[ci] Use setup OCaml for OPAM setup 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,11 @@ jobs:
   build:
     strategy:
       matrix:
-        jscoq_arch: [32, 64]
+        include:
+          - jscoq_arch: 32
+            ocaml_compiler: "ocaml-variants.4.12.0+options,ocaml-option-32bit"
+          - jscoq_arch: 64
+            ocaml_compiler: "ocaml-base-compiler.4.12.0"
     env:
       OPAMJOBS: "2"
       OPAMROOTISOK: "true"
@@ -36,75 +40,82 @@ jobs:
       OPAM_MACOS_URL: https://github.com/ocaml/opam/releases/download/2.3.0/opam-2.3.0-x86_64-darwin
       WASI_SDK_URL: https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: 'true'
+      # OPAM figures out everything but the libgmp-dev:i386
+      # dependency, maybe worth fixing this upstream in the opam
+      # repository
       - name: Install apt dependencies
+        if: matrix.jscoq_arch == '32'
         run: |
           sudo apt-get install aptitude
           sudo dpkg --add-architecture i386
           sudo aptitude -o Acquire::Retries=30 update -q
           sudo aptitude -o Acquire::Retries=30 install gcc-multilib g++-multilib pkg-config libgmp-dev:i386 -y
-      - uses: actions/setup-node@v4
+
+      - name: 🔭 Checkout code
+        uses: actions/checkout@v4
         with:
-          node-version: '22'
-          cache: 'npm'
-      - name: OPAM Setup
+          submodules: 'true'
+
+      - name: 🐫 Setup OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml_compiler}}
+          dune-cache: true
+
+      - name: 🐫🐪🐫 Get OCaml dependencies
         run: |
-          sudo curl -sL $OPAM_LINUX_URL -o /usr/bin/opam &&
-          sudo chmod 755 /usr/bin/opam
-      - name: OCaml Setup
-        run: |
-          opam init -y --bare --disable-sandboxing || true
-          eval $(opam env)
-          ./etc/toolchain-setup.sh --"$JSCOQ_ARCH"
+          ./etc/toolchain-setup.sh --"$JSCOQ_ARCH" --local --ci
           opam switch
           opam list
           opam config var root
+
+      - name: 🚀 Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
       - name: WASI Setup
         run: |
           wget --quiet -O/tmp/wasi-sdk.tar.gz ${WASI_SDK_URL}
           ( cd /opt && sudo tar xf /tmp/wasi-sdk.tar.gz && sudo ln -s wasi-sdk-* wasi-sdk )
-      - name: Coq build
-        run: |
-          echo 'Using Node.js:' && node --version
-          set -e
-          echo 'Building Coq...' # && echo -en 'travis_fold:start:coq.build\\r'
-          make coq-get
-          # echo -en 'travis_fold:end:coq.build\\r'
+
+      - name: Coq download, patching, and setup
+        run: make coq-get
+
       - name: jsCoq build (JSOO)
-        run: |
-          set -e
-          echo 'Building JsCoq (JSOO)...'
-          make jscoq
+        run: make jscoq
+
       - name: jsCoq build (WASM)
-        run: |
-          set -e
-          echo 'Building JsCoq (WACOQ)...'
-          make wacoq
+        run: make wacoq
+
       - name: jsCoq addons
         run: |
           set -e
           echo 'Building addons disabled...'
-          # echo 'Building Addons...'
-          # EJGA: We need to resurrect this
           # make addons
+
       - name: jsCoq test
+        if: false
         run: |
           set -e
           echo 'Testing JsCoq disabled...'
           # EJGA: Disabled for now, we need to see how to update the CLI
           # npm install # EJGA: uggg, but otherwise this won't work.
           # make test
+
       - name: Prepare artifact
         run: make dist-artifact
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: jsCoq_${{ matrix.jscoq_arch }}_${{ github.sha }}
           path: _build/artifact
           compression-level: 9
+
   docker:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,19 @@ else
 VARIANT = +32bit
 endif
 
-BUILD_CONTEXT = jscoq$(VARIANT)
+# Local switch
+ifeq ($(SWITCH_NAME),.)
+BUILD_SWITCH = ${shell pwd}
+DUNE_WORKSPACE = $(current_dir)/dune-workspace.local
+BUILD_CONTEXT = default
+else
+BUILD_CONTEXT = $(SWITCH_NAME)
+BUILD_SWITCH = $(BUILD_CONTEXT)
+endif
+
 BUILDDIR = _build/$(BUILD_CONTEXT)
 
-DUNE = opam exec --switch=$(BUILD_CONTEXT) -- dune
+DUNE = opam exec --switch=$(BUILD_SWITCH) -- dune
 
 # ugly but I couldn't find a better way
 current_dir := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))

--- a/dune-workspace.local
+++ b/dune-workspace.local
@@ -3,6 +3,6 @@
 (profile release)
 
 (context
- (opam (switch jscoq+64bit)
+ (default
   (disable_dynamically_linked_foreign_archives false) ; https://github.com/ocaml/dune/issues/3262
   (merlin)))

--- a/etc/toolchain-setup.sh
+++ b/etc/toolchain-setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 NJOBS=4
 VERB= # -vv
 
@@ -15,6 +17,8 @@ case `uname` in
   *)      WORD_SIZE=32 ;;
 esac
 
+# Dune compilation breaks if use a CI variable lol
+JSCOQ_CI=no
 WRITE_CONFIG=no
 
 if [ -e config.inc ] ; then . config.inc
@@ -22,8 +26,10 @@ else WRITE_CONFIG=yes ; fi
 
 for i in "$@"; do
   case $i in
-    --32) WORD_SIZE=32; WRITE_CONFIG=yes ;;
-    --64) WORD_SIZE=64; WRITE_CONFIG=yes ;;
+    --32) WORD_SIZE=32; WRITE_CONFIG=yes; switch_name=jscoq+32bit;;
+    --64) WORD_SIZE=64; WRITE_CONFIG=yes; switch_name=jscoq+64bit;;
+    --ci) WRITE_CONFIG=yes; JSCOQ_CI=yes;;
+    --local) WRITE_CONFIG=yes; switch_name=.;;
     *)    echo "unknown option '$i'."; exit ;;
   esac
 done
@@ -31,24 +37,33 @@ done
 create_switch() {
 
   case $WORD_SIZE in
-    32) switch_name=jscoq+32bit; packages="ocaml-variants.$OCAML_VER+options,ocaml-option-32bit";;
-    64) switch_name=jscoq+64bit; packages=ocaml-base-compiler.$OCAML_VER ;;
+    32) packages="ocaml-variants.$OCAML_VER+options,ocaml-option-32bit";;
+    64) packages=ocaml-base-compiler.$OCAML_VER ;;
   esac
 
-  opam switch -j $NJOBS create $switch_name --packages=$packages
-  opam switch $switch_name || exit
-  eval `opam env`
-
+  # In CI _opam is setup by setup-ocaml action
+  if [[ $JSCOQ_CI == 'no' ]]
+  then
+      opam switch -j $NJOBS create $switch_name --packages=$packages -y
+      opam switch $switch_name || exit
+  fi
 }
 
 install_deps() {
 
-  opam update
+  if [[ $JSCOQ_CI == 'no' ]]
+  then
+      opam update
+      opam pin add -y -n --kind=path jscoq .
+  fi
 
-  opam pin add -y -n --kind=path jscoq .
+  # Setup-ocaml action does perform the pinning
   opam install -y --deps-only $VERB -j $NJOBS jscoq
-  opam pin remove jscoq
 
+  if [[ $JSCOQ_CI == 'no' ]]
+  then
+      opam pin remove jscoq
+  fi
 }
 
 post_install() {
@@ -58,13 +73,15 @@ post_install() {
   # 32-bit native compilation on macOS is broken and we found no other
   # way to disable it.
   # This has to take place only after install_deps.
+  eval $(opam env)
+
   case `uname`/$WORD_SIZE in
     Darwin/32) rm -f $OPAM_SWITCH_PREFIX/bin/ocamlopt* ;;
   esac
 
 }
 
-if [ $WRITE_CONFIG == yes ] ; then echo "WORD_SIZE=$WORD_SIZE" > config.inc ; fi
+if [ $WRITE_CONFIG == yes ] ; then echo -e "WORD_SIZE=$WORD_SIZE\nSWITCH_NAME=$switch_name" > config.inc ; fi
 
 create_switch
 install_deps


### PR DESCRIPTION
This enables the dune / opam cache, which makes CI much faster.

We also incorporate some other improvements from coq-lsp CI.