### PR TITLE
[build] fix argument issue in toolchain-setup.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
   docker:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      REPOS_URL: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -139,6 +140,8 @@ jobs:
           target: jscoq-addons
           push: false
           tags: jscoq/jscoq:latest
-          build-args: BRANCH=${{ env.BRANCH_NAME }}
+          build-args: |
+            BRANCH=${{ env.BRANCH_NAME }}
+            JSCOQ_REPO=https://github.com/${{ env.REPOS_URL }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,8 @@
    jsCoq hard to use in non US keyboards layouts, like French or
    Spanish (@helguo, #395 , cc
    https://github.com/ejgallego/CodeMirror-TeX-input/pull/3 )
+ - Have Docker CI use the PR repository when doing CI for a PR CI
+   (@helguo, @ejgallego, cc #321, #)
 
 # jsCoq 0.17.1 "Night slip"
 ---------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,8 +46,10 @@
    jsCoq hard to use in non US keyboards layouts, like French or
    Spanish (@helguo, #395 , cc
    https://github.com/ejgallego/CodeMirror-TeX-input/pull/3 )
+ - [build] Fix bug about opam switch name in `toolchain-setup.sh`
+   introduced in #387 (@helguo, #396)
  - Have Docker CI use the PR repository when doing CI for a PR CI
-   (@helguo, @ejgallego, cc #321, #)
+   (@helguo, @ejgallego, cc: #321, #397)
 
 # jsCoq 0.17.1 "Night slip"
 ---------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ make serve
 
 then point your browser to `http://localhost:8013`
 
-See [./docs/build](./docs/build) for more detailed information on
+See [build.md](./docs/build.md) for more detailed information on
 build and dependencies.
 
 ### Project and source code organization
@@ -87,19 +87,19 @@ We prefer GPG signed commits as well as `Signed-off-by` commits.
 
 We have some [soft] commit tag conventions:
 
-- [jscoq]: ML/Coq interface
-- [ui]: Html/Css commit
-- [cm]: CodeMirror provider
-- [libs]: Coq Library support and format
-- [doc]: Documentation
-- [addons]: Addons support
-- [build]: Build system
-- [feature]: Adding a new feature
-- [bugfix]: Bug fix
-- [refactor]: Refactoring commit (no functional change intended)
-- [ci] / [travis]: Continuous integration
-- [test]: Adding or modifying a test
-- [misc]: Miscellanenous small things
+- [jscoq] : ML/Coq interface
+- [ui] : Html/Css commit
+- [cm] : CodeMirror provider
+- [libs] : Coq Library support and format
+- [doc] : Documentation
+- [addons] : Addons support
+- [build] : Build system
+- [feature] : Adding a new feature
+- [bugfix] : Bug fix
+- [refactor] : Refactoring commit (no functional change intended)
+- [ci] / [travis] : Continuous integration
+- [test] : Adding or modifying a test
+- [misc] : Miscellanenous small things
 
 ### Previous jsCoq versions
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ more information.
 
 The current _development version_ is jsCoq 1.99.1, targeting Coq 8.17
 to Coq 8.21. The current development version is based on the new
-[Flèche](https:://github.com/ejgallego/coq-lsp) document manager and
+[Flèche](https://github.com/ejgallego/coq-lsp) document manager and
 has significant changes. If you are interested in helping with this
 effort, please get in touch with us.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -6,7 +6,7 @@ on a Unix-like system. The required packages can be obtained using
 
 ## System-level Prerequisites
 
-In case of problems, we recommend looking first at our [Dockerfile](../etc/Docker/Dockerfile)
+In case of problems, we recommend looking first at our [Dockerfile](../etc/docker/Dockerfile)
 which contains detailed package and build instructions for Debian (and please feel free
 to contribute a OSX CI job).
 
@@ -48,7 +48,7 @@ packages into a switch called `jscoq+32bit`.
 
 On macOS 10.14 and above, and on WSL you will have trouble building
  32-bit executables. To use a 64-bit toolchain, include the `--64` flag:
-```
+```sh
 ./etc/toolchain-setup.sh --64
 ```
 
@@ -60,7 +60,7 @@ tree.
  _Word of caution about the 64-bit build:_ Using `--64` means that `.vo` files will be compiled on your native 64-bit architecture, using [a patch](https://github.com/jscoq/jscoq/blob/v8.16/etc/patches/coerce-32bit.patch) that attempts to make them compatible with the 32-bit runtime in the browser.
  While this has worked so far, it is brittle and may cause some unexpected behavior in certain corner cases.
 
-**Important Note:** If you plan to build any addons which are built using `coq_makefile`, then you should run `opam switch jscoq+32bit` [or `+64bits`] before any `make` command, in order to choose the right version
+**Important Note:** If you plan to build any addons which are built using `coq_makefile`, then you should run `opam switch jscoq+32bit` [or `+64bit`] before any `make` command, in order to choose the right version
 of OCaml and Coq.
 For Dune builds, configure the switch in your `dune-workspace`.
 
@@ -79,15 +79,15 @@ To build a usable jsCoq version, just do:
 make jscoq
 ```
 
-This will create a working distribution under `_build/jscoq+32bit/` (or `_build/jscoq+64bit`).
+This will create a working distribution under `_build/jscoq+32bit/` (or `_build/jscoq+64bit/`).
 
 Now serve the files from the distribution directory via HTTP (`make serve`), and
-navigate your browser to `http://localhost:8030/`.
+navigate your browser to `http://localhost:8013/`.
 
 You can also build the `wacoq` version using:
 
 ```sh
-make jscoq
+make wacoq
 ```
 
 ### Debugging
@@ -123,7 +123,7 @@ make
 ```
 
  8. Create NPM packages for compiled libraries.
-```
+```sh
 make pack   # in jscoq-addons working directory
 ```
 

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -1,8 +1,4 @@
-# Base branch, used for addons
-ARG BASE_BRANCH=v8.20
-# jsCoq branch, to be overriden for example in PRs
-ARG BRANCH=v8.20
-
+# Standard arguments
 ARG WORDSIZE=32
 ARG SWITCH=jscoq+${WORDSIZE}bit
 
@@ -60,13 +56,13 @@ ARG SWITCH
 ARG WORDSIZE
 RUN if [ ${WORDSIZE} != 32 ] ; then opam switch create ${SWITCH} 4.12.0 ; fi
 RUN if [ ${WORDSIZE} = 32 ] ;  then opam switch create ${SWITCH} --packages="ocaml-variants.4.12.0+options,ocaml-option-32bit" ; fi
-ARG BRANCH
 
+# jsCoq branch, to be overriden for example in PRs
+ARG BRANCH=v8.20
 ARG JSCOQ_REPO=https://github.com/jscoq/jscoq
-ARG JSCOQ_BRANCH=${BRANCH}
 
 WORKDIR /root
-RUN git clone --recursive -b ${JSCOQ_BRANCH} ${JSCOQ_REPO}
+RUN git clone --recursive -b ${BRANCH} ${JSCOQ_REPO}
 
 WORKDIR jscoq
 RUN ./etc/toolchain-setup.sh --${WORDSIZE}
@@ -78,11 +74,8 @@ RUN opam list
 # -----------
 FROM jscoq-base AS jscoq
 
-ARG SUB_BRANCH
 ARG NJOBS=4
 
-RUN git pull --ff-only
-RUN if [ _${SUB_BRANCH} != _ ] ; then git checkout ${SUB_BRANCH} && git pull --ff-only ; fi
 RUN eval $(opam env) && make coq
 RUN export JSCOQ_BUNDLE_TARGET=release
 RUN eval $(opam env) && make jscoq
@@ -101,12 +94,11 @@ FROM jscoq AS jscoq-addons
 RUN eval $(opam env) && make install &&   \
     cd _build/jscoq+* && npm link
 
-ARG BASE_BRANCH
-ARG BRANCH
+# Base branch, used for addons
 ARG WORDSIZE
 ARG SWITCH
 ARG ADDONS_REPO=https://github.com/jscoq/addons
-ARG ADDONS_BRANCH=${BASE_BRANCH}
+ARG ADDONS_BRANCH=v8.20
 
 # - fetch submodules with ssh urls using https instead
 #   (to avoid the need for an ssh key)
@@ -135,12 +127,10 @@ RUN make pack CONTEXT=${SWITCH}
 
 FROM jscoq-addons AS jscoq-inc
 
-ARG SUB_BRANCH
 ARG NJOBS=4
 
 WORKDIR /root/jscoq
 RUN git pull --ff-only
-RUN if [ _${SUB_BRANCH} != _ ] ; then git checkout ${SUB_BRANCH} && git pull --ff-only ; fi
 RUN eval $(opam env) && make jscoq
 
 # - dist tarballs

--- a/etc/toolchain-setup.sh
+++ b/etc/toolchain-setup.sh
@@ -18,41 +18,36 @@ case `uname` in
 esac
 
 # Dune compilation breaks if use a CI variable lol
+JSCOQ_LOCAL=no
 JSCOQ_CI=no
-WRITE_CONFIG=no
 
-if [ -e config.inc ] ; then . config.inc
-else WRITE_CONFIG=yes ; fi
-
-if [ $# -eq 0 ] ; then
-  # require an argument
-  # echo "no argument provided."
-  # echo "usage : $(basename $0) {--32 | -- 64 | --ci | --local}";
-  # exit
-
-  # --32 as default
-  WORD_SIZE=32; WRITE_CONFIG=yes; switch_name=jscoq+32bit
-fi
-
+# Process argument
 for i in "$@"; do
   case $i in
-    --32) WORD_SIZE=32; WRITE_CONFIG=yes; switch_name=jscoq+32bit;;
-    --64) WORD_SIZE=64; WRITE_CONFIG=yes; switch_name=jscoq+64bit;;
-    --ci) WRITE_CONFIG=yes; JSCOQ_CI=yes;;
-    --local) WRITE_CONFIG=yes; switch_name=.;;
+    --32) WORD_SIZE=32 ;;
+    --64) WORD_SIZE=64 ;;
+    --ci) JSCOQ_CI=yes ;;
+    --local) JSCOQ_LOCAL=yes ;;
     *)    echo "unknown option '$i'."; exit ;;
   esac
 done
 
+# Build switch name
+if [ "$JSCOQ_LOCAL" = "yes" ] ; then
+  switch_name=.
+else
+  switch_name=jscoq+"$WORD_SIZE"bit
+fi
+
 create_switch() {
 
   case $WORD_SIZE in
-    32) packages="ocaml-variants.$OCAML_VER+options,ocaml-option-32bit";;
+    32) packages="ocaml-variants.$OCAML_VER+options,ocaml-option-32bit" ;;
     64) packages=ocaml-base-compiler.$OCAML_VER ;;
   esac
 
   # In CI _opam is setup by setup-ocaml action
-  if [[ $JSCOQ_CI == 'no' ]]
+  if [ "$JSCOQ_CI" = "no" ] ;
   then
       opam switch -j $NJOBS create $switch_name --packages=$packages -y
       opam switch $switch_name || exit
@@ -61,7 +56,7 @@ create_switch() {
 
 install_deps() {
 
-  if [[ $JSCOQ_CI == 'no' ]]
+  if [ "$JSCOQ_CI" = "no" ] ;
   then
       opam update
       opam pin add -y -n --kind=path jscoq .
@@ -70,7 +65,7 @@ install_deps() {
   # Setup-ocaml action does perform the pinning
   opam install -y --deps-only $VERB -j $NJOBS jscoq
 
-  if [[ $JSCOQ_CI == 'no' ]]
+  if [ "$JSCOQ_CI" = "no" ] ;
   then
       opam pin remove jscoq
   fi
@@ -91,7 +86,8 @@ post_install() {
 
 }
 
-if [ $WRITE_CONFIG == yes ] ; then echo -e "WORD_SIZE=$WORD_SIZE\nSWITCH_NAME=$switch_name" > config.inc ; fi
+# Write config
+echo -e "WORD_SIZE=$WORD_SIZE\nSWITCH_NAME=$switch_name" > config.inc ;
 
 create_switch
 install_deps

--- a/etc/toolchain-setup.sh
+++ b/etc/toolchain-setup.sh
@@ -24,6 +24,16 @@ WRITE_CONFIG=no
 if [ -e config.inc ] ; then . config.inc
 else WRITE_CONFIG=yes ; fi
 
+if [ $# -eq 0 ] ; then
+  # require an argument
+  # echo "no argument provided."
+  # echo "usage : $(basename $0) {--32 | -- 64 | --ci | --local}";
+  # exit
+
+  # --32 as default
+  WORD_SIZE=32; WRITE_CONFIG=yes; switch_name=jscoq+32bit
+fi
+
 for i in "$@"; do
   case $i in
     --32) WORD_SIZE=32; WRITE_CONFIG=yes; switch_name=jscoq+32bit;;


### PR DESCRIPTION
`toolchain-setup.sh` failed to create an `opam switch` (for example `jscoq+32bit`) because no argument is given.
The switch name is built correctly now.
